### PR TITLE
Adds missing first argument to Grid.row

### DIFF
--- a/src/Bootstrap/Modal.elm
+++ b/src/Bootstrap/Modal.elm
@@ -63,7 +63,7 @@ module Bootstrap.Modal
                 |> Modal.h5 [] [ text "Modal header" ]
                 |> Modal.body []
                     [ Grid.containerFluid []
-                        [ Grid.row
+                        [ Grid.row []
                             [ Grid.col
                                 [ Col.xs6 ]
                                 [ text "Col 1" ]


### PR DESCRIPTION
Grid.row takes two arguments, but the example code was only sending in 1 argument.